### PR TITLE
Improve language detection using `langid`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-charset-normalizer == 2.0.12
+chardet == 5.0.0
 iso639 == 0.1.4
+langid == 1.1.6
+srt == 3.5.2


### PR DESCRIPTION
First of all: apologies for submitting another PR which basically reverts some of the changes of my previous PR (#5).

I had actually never tested #5 on a large set of subtitle fails, and as soon as I did I started seeing unexpected results. The `charset-normalizer` library I have introduced in #5 doesn't really perform that good on language detection. I opened an issue upstream (https://github.com/Ousret/charset_normalizer/issues/200) but the outcome of that is still not great—it fails detecting the correct language of around 30% of my subtitle files.

I decided to get rid of `charset-normalizer` to detect language, and update the processing of subtitle files as follows:
- Use `chardet` to detect the file encoding, in case the file is not UTF-8, so that we can still do language detection of files with other types of encoding (which `charset-normalizer` was doing too)
- Use `langid` for language detection, which never fails on my list of subtitle files (around 600 files)

Thank you in advance for considering my proposed changes.
